### PR TITLE
Experiment: Less verbose api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [dependencies]
 tonic = "0.1"
-bytes = "0.4"
+bytes = "0.5"
 prost = "0.6"
 tokio = { version = "0.2", features = ["stream"] }
 async-stream = "0.2"

--- a/examples/lease.rs
+++ b/examples/lease.rs
@@ -11,17 +11,12 @@ async fn grant_lease(client: &Client) -> Result<()> {
 
     {
         // watch key modification
-        let mut inbound = client.watch().responses();
+        let mut inbound = client.watch(KeyRange::key(key));
         tokio::spawn(async move {
-            loop {
-                let resp = inbound.next().await.unwrap();
+            while let Some(resp) = inbound.next().await {
                 println!("watch response: {:?}", resp);
             }
         });
-        client
-            .watch()
-            .watch(WatchRequest::create(KeyRange::key(key)))
-            .await;
     }
 
     let lease = client
@@ -51,17 +46,12 @@ async fn keep_alive_lease(client: &Client) -> Result<()> {
 
     {
         // watch key modification
-        let mut inbound = client.watch().responses();
+        let mut inbound = client.watch(KeyRange::key(key));
         tokio::spawn(async move {
-            loop {
-                let resp = inbound.next().await.unwrap();
+            while let Some(resp) = inbound.next().await {
                 println!("watch response: {:?}", resp);
             }
         });
-        client
-            .watch()
-            .watch(WatchRequest::create(KeyRange::key(key)))
-            .await;
     }
 
     // grant lease

--- a/examples/watch.rs
+++ b/examples/watch.rs
@@ -6,20 +6,15 @@ async fn watch(client: &Client) -> Result<()> {
     println!("watch key value modification");
 
     {
+        let mut inbound = client.watch(KeyRange::key("foo"));
+
         // print out all received watch responses
-        let mut inbound = client.watch().responses();
         tokio::spawn(async move {
-            loop {
-                let resp = inbound.next().await.unwrap();
+            while let Some(resp) = inbound.next().await {
                 println!("watch response: {:?}", resp);
             }
         });
     }
-
-    client
-        .watch()
-        .watch(WatchRequest::create(KeyRange::key("foo")))
-        .await;
 
     let key = "foo";
     client.kv().put(PutRequest::new(key, "bar")).await?;

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -5,7 +5,7 @@ pub use authenticate::{AuthenticateRequest, AuthenticateResponse};
 use tonic::transport::Channel;
 
 use crate::proto::etcdserverpb::auth_client::AuthClient;
-use crate::Result;
+use crate::Result as Res;
 
 /// Auth client.
 #[derive(Clone)]
@@ -20,7 +20,7 @@ impl Auth {
 
     /// Performs an authenticating operation.
     /// It generates an authentication token based on a given user name and password.
-    pub async fn authenticate(&mut self, req: AuthenticateRequest) -> Result<AuthenticateResponse> {
+    pub async fn authenticate(&mut self, req: AuthenticateRequest) -> Res<AuthenticateResponse> {
         let resp = self
             .client
             .authenticate(tonic::Request::new(req.into()))

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,7 @@ use crate::proto::etcdserverpb::{
     auth_client::AuthClient, kv_client::KvClient, lease_client::LeaseClient,
     watch_client::WatchClient,
 };
-use crate::{Auth, Kv, Lease, Result, Watch};
+use crate::{Auth, Kv, Lease, Result as Res, Watch};
 
 /// Config for establishing etcd client.
 pub struct ClientConfig {
@@ -32,7 +32,7 @@ pub(crate) struct Inner {
 impl Client {
     /// Connects to etcd generate auth token.
     /// The client connection used to request the authentication token is typically thrown away; it cannot carry the new token’s credentials. This is because gRPC doesn’t provide a way for adding per RPC credential after creation of the connection
-    async fn generate_auth_token(endpoints: Vec<String>, auth: (String, String)) -> Result<String> {
+    async fn generate_auth_token(endpoints: Vec<String>, auth: (String, String)) -> Res<String> {
         use crate::AuthenticateRequest;
 
         let channel = {
@@ -54,7 +54,7 @@ impl Client {
     }
 
     /// Connects to etcd cluster and returns a client.
-    pub async fn connect(cfg: ClientConfig) -> Result<Self> {
+    pub async fn connect(cfg: ClientConfig) -> Res<Self> {
         // If authentication provided, geneartes token before connecting.
         let token = match cfg.auth {
             Some(auth) => {

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -12,7 +12,7 @@ use tonic::transport::Channel;
 
 use crate::proto::etcdserverpb::kv_client::KvClient;
 use crate::proto::mvccpb;
-use crate::Result;
+use crate::Result as Res;
 
 /// Key-Value client.
 #[derive(Clone)]
@@ -26,21 +26,21 @@ impl Kv {
     }
 
     /// Performs a key-value saving operation.
-    pub async fn put(&mut self, req: PutRequest) -> Result<PutResponse> {
+    pub async fn put(&mut self, req: PutRequest) -> Res<PutResponse> {
         let resp = self.client.put(tonic::Request::new(req.into())).await?;
 
         Ok(From::from(resp.into_inner()))
     }
 
     /// Performs a key-value fetching operation.
-    pub async fn range(&mut self, req: RangeRequest) -> Result<RangeResponse> {
+    pub async fn range(&mut self, req: RangeRequest) -> Res<RangeResponse> {
         let resp = self.client.range(tonic::Request::new(req.into())).await?;
 
         Ok(From::from(resp.into_inner()))
     }
 
     /// Performs a key-value deleting operation.
-    pub async fn delete(&mut self, req: DeleteRequest) -> Result<DeleteResponse> {
+    pub async fn delete(&mut self, req: DeleteRequest) -> Res<DeleteResponse> {
         let resp = self
             .client
             .delete_range(tonic::Request::new(req.into()))
@@ -50,7 +50,7 @@ impl Kv {
     }
 
     /// Performs a transaction operation.
-    pub async fn txn(&mut self, req: TxnRequest) -> Result<TxnResponse> {
+    pub async fn txn(&mut self, req: TxnRequest) -> Res<TxnResponse> {
         let resp = self.client.txn(tonic::Request::new(req.into())).await?;
 
         Ok(From::from(resp.into_inner()))

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -17,18 +17,12 @@
 //!     }).await?;
 //!
 //!     // print out all received watch responses
-//!     let mut inbound = client.watch().responses();
+//!     let mut inbound = client.watch(KeyRange::key("foo"));
 //!     tokio::spawn(async move {
-//!         loop {
-//!             let resp = inbound.next().await.unwrap();
+//!         while let Some(resp) = inbound.next().await {
 //!             println!("watch response: {:?}", resp);
 //!         }
 //!     });
-//!
-//!     client
-//!         .watch()
-//!         .watch(WatchRequest::create(KeyRange::key("foo")))
-//!         .await;
 //!
 //!     let key = "foo";
 //!     client.kv().put(PutRequest::new(key, "bar")).await?;


### PR DESCRIPTION
This is an experiment that reduces the amount of repetition involved in making API calls. I only made the change to the watch API, but I can apply a similar change to the other APIs if this is a desirable change.

Before:
```rust
client
    .watch()
    .watch(WatchRequest::create(KeyRange::key("foo")))
    .await;
```

After:
```rust
client.watch(KeyRange::key("base_path")).await;
```