### PR TITLE
Use Tokio's RwLock

### DIFF
--- a/examples/lease.rs
+++ b/examples/lease.rs
@@ -64,7 +64,7 @@ async fn keep_alive_lease(client: &Client) -> Result<()> {
 
     {
         // watch keep alive event
-        let mut inbound = client.lease().keep_alive_responses();
+        let mut inbound = client.lease().keep_alive_responses().await;
         tokio::spawn(async move {
             loop {
                 let resp = inbound.next().await.unwrap();

--- a/examples/lease.rs
+++ b/examples/lease.rs
@@ -11,7 +11,7 @@ async fn grant_lease(client: &Client) -> Result<()> {
 
     {
         // watch key modification
-        let mut inbound = client.watch(KeyRange::key(key));
+        let mut inbound = client.watch(KeyRange::key(key)).await;
         tokio::spawn(async move {
             while let Some(resp) = inbound.next().await {
                 println!("watch response: {:?}", resp);
@@ -46,7 +46,7 @@ async fn keep_alive_lease(client: &Client) -> Result<()> {
 
     {
         // watch key modification
-        let mut inbound = client.watch(KeyRange::key(key));
+        let mut inbound = client.watch(KeyRange::key(key)).await;
         tokio::spawn(async move {
             while let Some(resp) = inbound.next().await {
                 println!("watch response: {:?}", resp);

--- a/examples/watch.rs
+++ b/examples/watch.rs
@@ -6,7 +6,7 @@ async fn watch(client: &Client) -> Result<()> {
     println!("watch key value modification");
 
     {
-        let mut inbound = client.watch(KeyRange::key("foo"));
+        let mut inbound = client.watch(KeyRange::key("foo")).await;
 
         // print out all received watch responses
         tokio::spawn(async move {

--- a/src/client.rs
+++ b/src/client.rs
@@ -143,12 +143,12 @@ impl Client {
     }
 
     /// Perform a watch operation
-    pub fn watch(
+    pub async fn watch(
         &self,
         key_range: KeyRange,
     ) -> impl Stream<Item = Result<WatchResponse, tonic::Status>> {
         let mut client = self.inner.watch_client.clone();
-        client.watch(key_range)
+        client.watch(key_range).await
     }
 
     /// Gets a lease client.

--- a/src/lease/mod.rs
+++ b/src/lease/mod.rs
@@ -63,10 +63,11 @@ pub use grant::{LeaseGrantRequest, LeaseGrantResponse};
 pub use keep_alive::{LeaseKeepAliveRequest, LeaseKeepAliveResponse};
 pub use revoke::{LeaseRevokeRequest, LeaseRevokeResponse};
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use tokio::stream::Stream;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio::sync::RwLock;
 use tonic::transport::Channel;
 
 use crate::proto::etcdserverpb;
@@ -165,17 +166,17 @@ impl Lease {
     }
 
     /// Fetch keep alive response stream.
-    pub fn keep_alive_responses(
+    pub async fn keep_alive_responses(
         &mut self,
     ) -> impl Stream<Item = Result<LeaseKeepAliveResponse, tonic::Status>> {
-        self.keep_alive_tunnel.write().unwrap().take_resp_receiver()
+        self.keep_alive_tunnel.write().await.take_resp_receiver()
     }
 
     /// Performs a lease refreshing operation.
     pub async fn keep_alive(&mut self, req: LeaseKeepAliveRequest) {
         self.keep_alive_tunnel
             .write()
-            .unwrap()
+            .await
             .req_sender
             .send(req)
             .unwrap();


### PR DESCRIPTION
The standard library `RwLock` blocks the thread until the lock can be acquired. This will block an entire tokio executor thread. This is undesirable because the current thread may already hold a lock, which would cause a panic or deadlock. The Tokio `RwLock` implementation is task aware and will queue the lock request until other tasks drop their locks.

<s>This builds on https://github.com/luncj/etcd-rs/pull/20.</s> rebased on master

[Tokio RwLock docs](https://docs.rs/tokio/0.2.11/tokio/sync/struct.RwLock.html)