### PR TITLE
TLS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/etcd-rs"
 license = "MIT"
 
 [dependencies]
-tonic = { version = "0.1", features = ["tls"] }
+tonic = { version = "0.2", features = ["tls"] }
 bytes = "0.5"
 prost = "0.6"
 tokio = { version = "0.2", features = ["stream"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/etcd-rs"
 license = "MIT"
 
 [dependencies]
-tonic = "0.1"
+tonic = { version = "0.1", features = ["tls"] }
 bytes = "0.5"
 prost = "0.6"
 tokio = { version = "0.2", features = ["stream"] }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ let endpoints = vec!["http://127.0.0.1:2379".to_owned()];
 let client = Client::connect(ClientConfig {
     endpoints,
     auth: None,
+    tls: None
 }).await;
 ```
 
@@ -63,6 +64,20 @@ let endpoints = vec!["http://127.0.0.1:2379".to_owned()];
 let client = Client::connect(ClientConfig {
     endpoints,
     auth: Some(("user".to_owned(), "password".to_owned())),
+    tls: None
+}).await;
+```
+
+with tls
+
+```rust
+let endpoints = vec!["https://127.0.0.1:2379".to_owned()];
+let tls = ClientTlsConfig::new();
+
+let client = Client::connect(ClientConfig {
+    endpoints,
+    auth: Some(("user".to_owned(), "password".to_owned())),
+    tls: Some(tls)
 }).await;
 ```
 

--- a/examples/kv.rs
+++ b/examples/kv.rs
@@ -102,6 +102,7 @@ async fn main() -> Result<()> {
     let client = Client::connect(ClientConfig {
         endpoints: vec!["http://127.0.0.1:2379".to_owned()],
         auth: None,
+        tls: None
     })
     .await?;
 

--- a/examples/kv.rs
+++ b/examples/kv.rs
@@ -102,7 +102,7 @@ async fn main() -> Result<()> {
     let client = Client::connect(ClientConfig {
         endpoints: vec!["http://127.0.0.1:2379".to_owned()],
         auth: None,
-        tls: None
+        tls: None,
     })
     .await?;
 

--- a/examples/lease.rs
+++ b/examples/lease.rs
@@ -115,6 +115,7 @@ async fn main() -> Result<()> {
     let client = Client::connect(ClientConfig {
         endpoints: vec!["http://127.0.0.1:2379".to_owned()],
         auth: None,
+        tls: None
     })
     .await?;
 

--- a/examples/lease.rs
+++ b/examples/lease.rs
@@ -115,7 +115,7 @@ async fn main() -> Result<()> {
     let client = Client::connect(ClientConfig {
         endpoints: vec!["http://127.0.0.1:2379".to_owned()],
         auth: None,
-        tls: None
+        tls: None,
     })
     .await?;
 

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -1,8 +1,8 @@
 use etcd_rs::*;
-use tonic::transport::{ClientTlsConfig, Certificate, Identity};
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+use tonic::transport::{Certificate, ClientTlsConfig, Identity};
 
 async fn put_and_get(client: &Client) -> Result<()> {
     println!("Put and get a key value pairs");
@@ -11,7 +11,6 @@ async fn put_and_get(client: &Client) -> Result<()> {
     let value = "bar";
 
     {
-
         // Put a key-value pair
         let req = PutRequest::new(key, value);
         println!("Put and ff a key value pairs");
@@ -44,9 +43,18 @@ async fn main() -> Result<()> {
     let mut cert: Vec<u8> = Vec::new();
     let mut key: Vec<u8> = Vec::new();
 
-    File::open(Path::new("ca.pem")).unwrap().read_to_end(&mut ca).unwrap();
-    File::open(Path::new("cert.pem")).unwrap().read_to_end(&mut cert).unwrap();
-    File::open(Path::new("key.pem")).unwrap().read_to_end(&mut key).unwrap();
+    File::open(Path::new("ca.pem"))
+        .unwrap()
+        .read_to_end(&mut ca)
+        .unwrap();
+    File::open(Path::new("cert.pem"))
+        .unwrap()
+        .read_to_end(&mut cert)
+        .unwrap();
+    File::open(Path::new("key.pem"))
+        .unwrap()
+        .read_to_end(&mut key)
+        .unwrap();
 
     let tls = ClientTlsConfig::new();
     let tls = tls.ca_certificate(Certificate::from_pem(ca));
@@ -57,7 +65,7 @@ async fn main() -> Result<()> {
         auth: None,
         tls: Some(tls),
     })
-        .await?;
+    .await?;
 
     put_and_get(&client).await?;
 

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -1,0 +1,65 @@
+use etcd_rs::*;
+use tonic::transport::{ClientTlsConfig, Certificate, Identity};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+async fn put_and_get(client: &Client) -> Result<()> {
+    println!("Put and get a key value pairs");
+
+    let key = "foo";
+    let value = "bar";
+
+    {
+
+        // Put a key-value pair
+        let req = PutRequest::new(key, value);
+        println!("Put and ff a key value pairs");
+
+        let resp = client.kv().put(req).await?;
+
+        println!("Put Response: {:?}", resp);
+    }
+
+    {
+        // Get the key-value pair
+        let req = RangeRequest::new(KeyRange::key(key));
+        let resp = client.kv().range(req).await?;
+        println!("Range Response: {:?}", resp);
+    }
+
+    {
+        // Delete the key-valeu pair
+        let req = DeleteRequest::new(KeyRange::key(key));
+        let resp = client.kv().delete(req).await?;
+        println!("Delete Response: {:?}", resp);
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut ca: Vec<u8> = Vec::new();
+    let mut cert: Vec<u8> = Vec::new();
+    let mut key: Vec<u8> = Vec::new();
+
+    File::open(Path::new("ca.pem")).unwrap().read_to_end(&mut ca).unwrap();
+    File::open(Path::new("cert.pem")).unwrap().read_to_end(&mut cert).unwrap();
+    File::open(Path::new("key.pem")).unwrap().read_to_end(&mut key).unwrap();
+
+    let tls = ClientTlsConfig::new();
+    let tls = tls.ca_certificate(Certificate::from_pem(ca));
+    let tls = tls.identity(Identity::from_pem(cert, key));
+
+    let client = Client::connect(ClientConfig {
+        endpoints: vec!["https://127.0.0.1:2379".to_owned()],
+        auth: None,
+        tls: Some(tls),
+    })
+        .await?;
+
+    put_and_get(&client).await?;
+
+    Ok(())
+}

--- a/examples/watch.rs
+++ b/examples/watch.rs
@@ -32,6 +32,7 @@ async fn main() -> Result<()> {
     let client = Client::connect(ClientConfig {
         endpoints: vec!["http://127.0.0.1:2379".to_owned()],
         auth: None,
+        tls: None
     })
     .await?;
 

--- a/examples/watch.rs
+++ b/examples/watch.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
     let client = Client::connect(ClientConfig {
         endpoints: vec!["http://127.0.0.1:2379".to_owned()],
         auth: None,
-        tls: None
+        tls: None,
     })
     .await?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,15 +36,13 @@ pub(crate) struct Inner {
 impl Client {
     fn get_channel(cfg: &ClientConfig) -> Channel {
         let endpoints = &cfg.endpoints;
-        let endpoints = endpoints
-            .into_iter()
-            .map(|e| {
-                let c = Channel::from_shared(e.to_owned()).expect("parse endpoint URI");
-                match &cfg.tls {
-                    Some(tls) => c.tls_config(tls.to_owned()),
-                    None => c
-                }
-            });
+        let endpoints = endpoints.into_iter().map(|e| {
+            let c = Channel::from_shared(e.to_owned()).expect("parse endpoint URI");
+            match &cfg.tls {
+                Some(tls) => c.tls_config(tls.to_owned()),
+                None => c,
+            }
+        });
         Channel::balance_list(endpoints)
     }
 
@@ -58,13 +56,11 @@ impl Client {
         let mut auth_client = Auth::new(AuthClient::new(channel));
 
         match cfg.auth.as_ref() {
-            Some((name, password)) => {
-                auth_client
-                    .authenticate(AuthenticateRequest::new(name, password))
-                    .await
-                    .and_then(|r| Ok(Some(r.token().to_owned())))
-            }
-            None => Ok(None)
+            Some((name, password)) => auth_client
+                .authenticate(AuthenticateRequest::new(name, password))
+                .await
+                .and_then(|r| Ok(Some(r.token().to_owned()))),
+            None => Ok(None),
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,6 +15,7 @@ use tonic::transport::ClientTlsConfig;
 pub struct ClientConfig {
     pub endpoints: Vec<String>,
     pub auth: Option<(String, String)>,
+    pub tls: Option<ClientTlsConfig>,
 }
 
 /// Client is an abstraction for grouping etcd operations and managing underlying network communications.
@@ -33,18 +34,26 @@ pub(crate) struct Inner {
 }
 
 impl Client {
+    fn get_channel(cfg: &ClientConfig) -> Channel {
+        let endpoints = &cfg.endpoints;
+        let endpoints = endpoints
+            .into_iter()
+            .map(|e| {
+                let c = Channel::from_shared(e.to_owned()).expect("parse endpoint URI");
+                match &cfg.tls {
+                    Some(tls) => c.tls_config(tls.to_owned()),
+                    None => c
+                }
+            });
+        Channel::balance_list(endpoints)
+    }
+
     /// Connects to etcd generate auth token.
     /// The client connection used to request the authentication token is typically thrown away; it cannot carry the new token’s credentials. This is because gRPC doesn’t provide a way for adding per RPC credential after creation of the connection
     async fn generate_auth_token(cfg: &ClientConfig) -> Res<Option<String>> {
         use crate::AuthenticateRequest;
 
-        let endpoints = &cfg.endpoints;
-        let channel = {
-            let endpoints = endpoints
-                .into_iter()
-                .map(|e| Channel::from_shared(e.to_owned()).expect("parse endpoint URI"));
-            Channel::balance_list(endpoints)
-        };
+        let channel = Self::get_channel(&cfg);
 
         let mut auth_client = Auth::new(AuthClient::new(channel));
 
@@ -75,13 +84,7 @@ impl Client {
             None
         };
 
-        let channel = {
-            let endpoints = cfg
-                .endpoints
-                .into_iter()
-                .map(|e| Channel::from_shared(e).expect("parse endpoint URI"));
-            Channel::balance_list(endpoints)
-        };
+        let channel = Self::get_channel(&cfg);
 
         let inner = {
             let (auth_client, kv_client, watch_client, lease_client) =

--- a/src/lease/mod.rs
+++ b/src/lease/mod.rs
@@ -14,6 +14,7 @@
 //!     let client = Client::connect(ClientConfig {
 //!         endpoints: vec!["http://127.0.0.1:2379".to_owned()],
 //!         auth: None,
+//!         tls: None,
 //!     }).await?;
 //!
 //!     let key = "foo";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //!     let client = Client::connect(ClientConfig {
 //!         endpoints: vec!["http://127.0.0.1:2379".to_owned()],
 //!         auth: None,
+//!         tls: None,
 //!     }).await?;
 //!
 //!     let key = "foo";

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -14,6 +14,7 @@
 //!     let client = Client::connect(ClientConfig {
 //!         endpoints: vec!["http://127.0.0.1:2379".to_owned()],
 //!         auth: None,
+//!         tls: None,
 //!     }).await?;
 //!
 //!     // print out all received watch responses


### PR DESCRIPTION
First of all: Thank you for a good usable etcdv3 crate!


Now that Tonic got tls-support for the load-balanced client (hyperium/tonic#338), it is possible to add true tls support to this crate as well.

This PR includes:

1. Some minor Client code refactoring to avoid too much code duplication for when a Channel is established.

2. Tonic 0.1 -> 0.2 (specifically v0.2.1 is required to get tls-support).

3. Add optional tls-config to the ClientConfig struct. **Note that this change breaks existing clients in that they will have to add `tls: None` explicitly.**

4. Update README with a minimal tls example and add a more comprehensive example in examples/tls.rs.


re 3) if you want, we can introduce a builder and/or default-pattern for the ClientConfig struct to avoid breaking clients when new fields are added in the future?

re 4) let me know if you want more or better docs + examples


I've tested this on my own tls-enabled production etcd cluster, with client cert auth enabled as well. I've also done a small regression test with tls disabled to ensure that I didn't break anything.