### PR TITLE
Expose TxnOpResponse to crate root

### DIFF
--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -6,7 +6,7 @@ mod txn;
 pub use delete::{DeleteRequest, DeleteResponse};
 pub use put::{PutRequest, PutResponse};
 pub use range::{RangeRequest, RangeResponse};
-pub use txn::{TxnCmp, TxnRequest, TxnResponse};
+pub use txn::{TxnCmp, TxnOpResponse, TxnRequest, TxnResponse};
 
 use tonic::transport::Channel;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub use auth::{Auth, AuthenticateRequest, AuthenticateResponse};
 pub use client::{Client, ClientConfig};
 pub use kv::{
     DeleteRequest, DeleteResponse, KeyRange, KeyValue, Kv, PutRequest, PutResponse, RangeRequest,
-    RangeResponse, TxnCmp, TxnRequest, TxnResponse,
+    RangeResponse, TxnCmp, TxnOpResponse, TxnRequest, TxnResponse,
 };
 pub use lease::{
     Lease, LeaseGrantRequest, LeaseGrantResponse, LeaseKeepAliveRequest, LeaseKeepAliveResponse,


### PR DESCRIPTION
Hey, thanks for the excellent crate! This PR just exposes `TxnOpResponse` in both the `kv` module and the crate root, as I needed it for code similar to:

```rust
let txn_responses = etcd_client.kv().txn(some_txn_req).await?.take_reponses();
for response in txn_responses {
	if let Some(TxnOpResponse::Range(range_res)) = response {
		// do stuff with range_res
	}
}
```

and `TxnOpResponse` was previously not publicly accessible, meaning you could get a response vec but not inspect the contents (unless I'm missing something obvious, in which case please throw away this PR 😃)