### PR TITLE
Reduce code duplication + export TxnOp

### DIFF
--- a/examples/lease.rs
+++ b/examples/lease.rs
@@ -12,7 +12,7 @@ async fn grant_lease(client: &Client) -> Result<()> {
 
     {
         // watch key modification
-        let mut inbound = client.watch(KeyRange::key(key)).await;
+        let mut inbound = client.watch(KeyRange::key(key)).await.unwrap();
         tokio::spawn(async move {
             while let Some(resp) = inbound.next().await {
                 println!("watch response: {:?}", resp);
@@ -47,7 +47,7 @@ async fn keep_alive_lease(client: &Client) -> Result<()> {
 
     {
         // watch key modification
-        let mut inbound = client.watch(KeyRange::key(key)).await;
+        let mut inbound = client.watch(KeyRange::key(key)).await.unwrap();
         tokio::spawn(async move {
             while let Some(resp) = inbound.next().await {
                 println!("watch response: {:?}", resp);
@@ -65,7 +65,7 @@ async fn keep_alive_lease(client: &Client) -> Result<()> {
 
     {
         // watch keep alive event
-        let mut inbound = client.lease().keep_alive_responses().await;
+        let mut inbound = client.lease().keep_alive_responses().await.unwrap();
         tokio::spawn(async move {
             loop {
                 match inbound.next().await {
@@ -103,7 +103,8 @@ async fn keep_alive_lease(client: &Client) -> Result<()> {
             client
                 .lease()
                 .keep_alive(LeaseKeepAliveRequest::new(lease_id))
-                .await;
+                .await
+                .unwrap();
         }
     }
 

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -17,7 +17,10 @@ async fn compose(cli: &mut Client) -> Result<()> {
         revision = resp.take_header().unwrap().revision();
 
         for v in 0..10 {
-            let _ = cli.kv().put(PutRequest::new(format!("key-{}", v), format!("{}", v))).await?;
+            let _ = cli
+                .kv()
+                .put(PutRequest::new(format!("key-{}", v), format!("{}", v)))
+                .await?;
         }
     }
 
@@ -53,7 +56,6 @@ async fn compose(cli: &mut Client) -> Result<()> {
     Ok(())
 }
 
-
 async fn cas(cli: &mut Client) -> Result<()> {
     reset(cli).await?;
     println!("start CAS section =====>");
@@ -86,7 +88,7 @@ async fn main() -> Result<()> {
         auth: None,
         tls: None,
     })
-        .await?;
+    .await?;
 
     // Compare-and-Set
     if let Err(e) = cas(&mut client).await {
@@ -97,7 +99,6 @@ async fn main() -> Result<()> {
     if let Err(e) = compose(&mut client).await {
         println!("failed to execute CAS: {:?}", e);
     }
-
 
     Ok(())
 }

--- a/examples/watch.rs
+++ b/examples/watch.rs
@@ -7,7 +7,7 @@ async fn watch(client: &Client) -> Result<()> {
     println!("watch key value modification");
 
     {
-        let mut inbound = client.watch(KeyRange::key("foo")).await;
+        let mut inbound = client.watch(KeyRange::key("foo")).await.unwrap();
 
         // print out all received watch responses
         tokio::spawn(async move {

--- a/src/auth/authenticate.rs
+++ b/src/auth/authenticate.rs
@@ -2,8 +2,8 @@ use crate::proto::etcdserverpb;
 use crate::ResponseHeader;
 
 pbwrap_request!(
-/// Request for authenticating.
-AuthenticateRequest
+    /// Request for authenticating.
+    AuthenticateRequest
 );
 
 impl AuthenticateRequest {

--- a/src/auth/authenticate.rs
+++ b/src/auth/authenticate.rs
@@ -1,10 +1,10 @@
 use crate::proto::etcdserverpb;
 use crate::ResponseHeader;
 
+pbwrap_request!(
 /// Request for authenticating.
-pub struct AuthenticateRequest {
-    proto: etcdserverpb::AuthenticateRequest,
-}
+AuthenticateRequest
+);
 
 impl AuthenticateRequest {
     pub fn new<N, P>(name: N, password: P) -> Self
@@ -20,17 +20,7 @@ impl AuthenticateRequest {
     }
 }
 
-impl Into<etcdserverpb::AuthenticateRequest> for AuthenticateRequest {
-    fn into(self) -> etcdserverpb::AuthenticateRequest {
-        self.proto
-    }
-}
-
-/// Response for authenticating.
-#[derive(Debug)]
-pub struct AuthenticateResponse {
-    proto: etcdserverpb::AuthenticateResponse,
-}
+pbwrap_response!(AuthenticateResponse);
 
 impl AuthenticateResponse {
     /// Takes the header out of response, leaving a `None` in its place.
@@ -44,11 +34,5 @@ impl AuthenticateResponse {
     /// Gets an authorized token that can be used in succeeding RPCs.
     pub fn token(&self) -> &str {
         &self.proto.token
-    }
-}
-
-impl From<etcdserverpb::AuthenticateResponse> for AuthenticateResponse {
-    fn from(resp: etcdserverpb::AuthenticateResponse) -> Self {
-        Self { proto: resp }
     }
 }

--- a/src/auth/authenticate.rs
+++ b/src/auth/authenticate.rs
@@ -26,7 +26,7 @@ impl AuthenticateResponse {
     /// Takes the header out of response, leaving a `None` in its place.
     pub fn take_header(&mut self) -> Option<ResponseHeader> {
         match self.proto.header.take() {
-            Some(header) => Some(From::from(header)),
+            Some(header) => Some(header.into()),
             _ => None,
         }
     }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -28,6 +28,6 @@ impl Auth {
             .authenticate(tonic::Request::new(req.into()))
             .await?;
 
-        Ok(From::from(resp.into_inner()))
+        Ok(resp.into_inner().into())
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -131,9 +131,12 @@ impl Client {
     }
 
     /// Perform a watch operation
-    pub async fn watch(&self, key_range: KeyRange) -> impl Stream<Item = Result<WatchResponse>> {
-        self.watch_client().watch(key_range).await;
-        self.watch_client().take_receiver().await
+    pub async fn watch(
+        &self,
+        key_range: KeyRange,
+    ) -> Result<impl Stream<Item = Result<WatchResponse>>> {
+        self.watch_client().watch(key_range).await?;
+        Ok(self.watch_client().take_receiver().await)
     }
 
     /// Gets a lease client.

--- a/src/client.rs
+++ b/src/client.rs
@@ -74,16 +74,13 @@ impl Client {
         // If authentication provided, generates token before connecting.
         let token = Self::generate_auth_token(&cfg).await?;
 
-        let auth_interceptor = if let Some(token) = token {
+        let auth_interceptor = token.map(|token| {
             let token = MetadataValue::from_str(&token).unwrap();
-            Some(Interceptor::new(move |mut req: Request<()>| {
+            Interceptor::new(move |mut req: Request<()>| {
                 req.metadata_mut().insert("authorization", token.clone());
-
                 Ok(req)
-            }))
-        } else {
-            None
-        };
+            })
+        });
 
         let channel = Self::get_channel(&cfg)?;
 
@@ -91,37 +88,25 @@ impl Client {
             let (auth_client, kv_client, watch_client, lease_client) =
                 if let Some(auth_interceptor) = auth_interceptor {
                     (
-                        Auth::new(AuthClient::with_interceptor(
-                            channel.clone(),
-                            auth_interceptor.clone(),
-                        )),
-                        Kv::new(KvClient::with_interceptor(
-                            channel.clone(),
-                            auth_interceptor.clone(),
-                        )),
-                        Watch::new(WatchClient::with_interceptor(
-                            channel.clone(),
-                            auth_interceptor.clone(),
-                        )),
-                        Lease::new(LeaseClient::with_interceptor(
-                            channel.clone(),
-                            auth_interceptor,
-                        )),
+                        AuthClient::with_interceptor(channel.clone(), auth_interceptor.clone()),
+                        KvClient::with_interceptor(channel.clone(), auth_interceptor.clone()),
+                        WatchClient::with_interceptor(channel.clone(), auth_interceptor.clone()),
+                        LeaseClient::with_interceptor(channel.clone(), auth_interceptor),
                     )
                 } else {
                     (
-                        Auth::new(AuthClient::new(channel.clone())),
-                        Kv::new(KvClient::new(channel.clone())),
-                        Watch::new(WatchClient::new(channel.clone())),
-                        Lease::new(LeaseClient::new(channel.clone())),
+                        AuthClient::new(channel.clone()),
+                        KvClient::new(channel.clone()),
+                        WatchClient::new(channel.clone()),
+                        LeaseClient::new(channel.clone()),
                     )
                 };
             Inner {
                 channel,
-                auth_client,
-                kv_client,
-                watch_client,
-                lease_client,
+                auth_client: Auth::new(auth_client),
+                kv_client: Kv::new(kv_client),
+                watch_client: Watch::new(watch_client),
+                lease_client: Lease::new(lease_client),
             }
         };
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -132,8 +132,8 @@ impl Client {
 
     /// Perform a watch operation
     pub async fn watch(&self, key_range: KeyRange) -> impl Stream<Item = Result<WatchResponse>> {
-        let mut client = self.inner.watch_client.clone();
-        client.watch(key_range).await
+        self.watch_client().watch(key_range).await;
+        self.watch_client().take_receiver().await
     }
 
     /// Gets a lease client.

--- a/src/kv/delete.rs
+++ b/src/kv/delete.rs
@@ -2,10 +2,10 @@ use super::{KeyRange, KeyValue};
 use crate::proto::etcdserverpb;
 use crate::ResponseHeader;
 
+pbwrap_request!(
 /// Request for deleting key-value pairs.
-pub struct DeleteRequest {
-    proto: etcdserverpb::DeleteRangeRequest,
-}
+DeleteRangeRequest => DeleteRequest
+);
 
 impl DeleteRequest {
     /// Creates a new DeleteRequest for the specified key range.
@@ -25,17 +25,7 @@ impl DeleteRequest {
     }
 }
 
-impl Into<etcdserverpb::DeleteRangeRequest> for DeleteRequest {
-    fn into(self) -> etcdserverpb::DeleteRangeRequest {
-        self.proto
-    }
-}
-
-/// Response for DeleteRequest.
-#[derive(Debug)]
-pub struct DeleteResponse {
-    proto: etcdserverpb::DeleteRangeResponse,
-}
+pbwrap_response!(DeleteRangeResponse => DeleteResponse);
 
 impl DeleteResponse {
     /// Takes the header out of response, leaving a `None` in its place.
@@ -61,11 +51,5 @@ impl DeleteResponse {
     /// Returns `true` if the previous key-value pairs is not empty, and `false` otherwise.
     pub fn has_prev_kvs(&self) -> bool {
         !self.proto.prev_kvs.is_empty()
-    }
-}
-
-impl From<etcdserverpb::DeleteRangeResponse> for DeleteResponse {
-    fn from(resp: etcdserverpb::DeleteRangeResponse) -> Self {
-        Self { proto: resp }
     }
 }

--- a/src/kv/delete.rs
+++ b/src/kv/delete.rs
@@ -3,8 +3,8 @@ use crate::proto::etcdserverpb;
 use crate::ResponseHeader;
 
 pbwrap_request!(
-/// Request for deleting key-value pairs.
-DeleteRangeRequest => DeleteRequest
+    /// Request for deleting key-value pairs.
+    DeleteRangeRequest => DeleteRequest
 );
 
 impl DeleteRequest {

--- a/src/kv/delete.rs
+++ b/src/kv/delete.rs
@@ -30,10 +30,7 @@ pbwrap_response!(DeleteRangeResponse => DeleteResponse);
 impl DeleteResponse {
     /// Takes the header out of response, leaving a `None` in its place.
     pub fn take_header(&mut self) -> Option<ResponseHeader> {
-        match self.proto.header.take() {
-            Some(header) => Some(From::from(header)),
-            _ => None,
-        }
+        self.proto.header.take().map(From::from)
     }
 
     /// Returns the number of keys deleted by the delete range request.
@@ -43,9 +40,10 @@ impl DeleteResponse {
 
     /// Takes the previous key-value pairs out of response, leaving an empty vector in its place.
     pub fn take_prev_kvs(&mut self) -> Vec<KeyValue> {
-        let kvs = std::mem::replace(&mut self.proto.prev_kvs, vec![]);
-
-        kvs.into_iter().map(From::from).collect()
+        std::mem::take(&mut self.proto.prev_kvs)
+            .into_iter()
+            .map(From::from)
+            .collect()
     }
 
     /// Returns `true` if the previous key-value pairs is not empty, and `false` otherwise.

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -29,14 +29,14 @@ impl Kv {
     pub async fn put(&mut self, req: PutRequest) -> Res<PutResponse> {
         let resp = self.client.put(tonic::Request::new(req.into())).await?;
 
-        Ok(From::from(resp.into_inner()))
+        Ok(resp.into_inner().into())
     }
 
     /// Performs a key-value fetching operation.
     pub async fn range(&mut self, req: RangeRequest) -> Res<RangeResponse> {
         let resp = self.client.range(tonic::Request::new(req.into())).await?;
 
-        Ok(From::from(resp.into_inner()))
+        Ok(resp.into_inner().into())
     }
 
     /// Performs a key-value deleting operation.
@@ -46,14 +46,14 @@ impl Kv {
             .delete_range(tonic::Request::new(req.into()))
             .await?;
 
-        Ok(From::from(resp.into_inner()))
+        Ok(resp.into_inner().into())
     }
 
     /// Performs a transaction operation.
     pub async fn txn(&mut self, req: TxnRequest) -> Res<TxnResponse> {
         let resp = self.client.txn(tonic::Request::new(req.into())).await?;
 
-        Ok(From::from(resp.into_inner()))
+        Ok(resp.into_inner().into())
     }
 }
 
@@ -71,7 +71,7 @@ impl KeyValue {
 
     /// Takes the key out of response, leaving an empty vector in its place.
     pub fn take_key(&mut self) -> Vec<u8> {
-        std::mem::replace(&mut self.proto.key, vec![])
+        std::mem::take(&mut self.proto.key)
     }
 
     /// Converts the key from bytes `&[u8]` to `&str`.
@@ -87,7 +87,7 @@ impl KeyValue {
 
     /// Takes the value out of response, leaving an empty vector in its place.
     pub fn take_value(&mut self) -> Vec<u8> {
-        std::mem::replace(&mut self.proto.value, vec![])
+        std::mem::take(&mut self.proto.value)
     }
 
     /// Converts the value from bytes `&[u8]` to `&str`.
@@ -130,8 +130,8 @@ impl From<mvccpb::KeyValue> for KeyValue {
 
 /// KeyRange is an abstraction for describing etcd key of various types.
 pub struct KeyRange {
-    key: Vec<u8>,
-    range_end: Vec<u8>,
+    pub key: Vec<u8>,
+    pub range_end: Vec<u8>,
 }
 
 impl KeyRange {
@@ -184,20 +184,12 @@ impl KeyRange {
             for i in (0..end.len()).rev() {
                 if end[i] < 0xff {
                     end[i] += 1;
-                    end = end[0..=i].to_vec();
+                    end.truncate(i + 1);
                     break;
                 }
             }
             end
         };
         Self { key, range_end }
-    }
-
-    pub fn take_key(&mut self) -> Vec<u8> {
-        std::mem::replace(&mut self.key, vec![])
-    }
-
-    pub fn take_range_end(&mut self) -> Vec<u8> {
-        std::mem::replace(&mut self.range_end, vec![])
     }
 }

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -6,7 +6,7 @@ mod txn;
 pub use delete::{DeleteRequest, DeleteResponse};
 pub use put::{PutRequest, PutResponse};
 pub use range::{RangeRequest, RangeResponse};
-pub use txn::{TxnCmp, TxnOpResponse, TxnRequest, TxnResponse};
+pub use txn::{TxnCmp, TxnOp, TxnOpResponse, TxnRequest, TxnResponse};
 
 use tonic::transport::Channel;
 

--- a/src/kv/put.rs
+++ b/src/kv/put.rs
@@ -2,10 +2,10 @@ use crate::proto::etcdserverpb;
 use crate::KeyValue;
 use crate::ResponseHeader;
 
+pbwrap_request!(
 /// Request for putting key-value.
-pub struct PutRequest {
-    proto: etcdserverpb::PutRequest,
-}
+PutRequest
+);
 
 impl PutRequest {
     /// Creates a new PutRequest for saving the specified key-value.
@@ -48,17 +48,7 @@ impl PutRequest {
     }
 }
 
-impl Into<etcdserverpb::PutRequest> for PutRequest {
-    fn into(self) -> etcdserverpb::PutRequest {
-        self.proto
-    }
-}
-
-/// Response for putting key-value.
-#[derive(Debug)]
-pub struct PutResponse {
-    proto: etcdserverpb::PutResponse,
-}
+pbwrap_response!(PutResponse);
 
 impl PutResponse {
     /// Takes the header out of response, leaving a `None` in its place.
@@ -75,11 +65,5 @@ impl PutResponse {
             Some(kv) => Some(From::from(kv)),
             _ => None,
         }
-    }
-}
-
-impl From<etcdserverpb::PutResponse> for PutResponse {
-    fn from(resp: etcdserverpb::PutResponse) -> Self {
-        Self { proto: resp }
     }
 }

--- a/src/kv/put.rs
+++ b/src/kv/put.rs
@@ -53,17 +53,11 @@ pbwrap_response!(PutResponse);
 impl PutResponse {
     /// Takes the header out of response, leaving a `None` in its place.
     pub fn take_header(&mut self) -> Option<ResponseHeader> {
-        match self.proto.header.take() {
-            Some(header) => Some(From::from(header)),
-            _ => None,
-        }
+        self.proto.header.take().map(From::from)
     }
 
     /// Takes the previous key-value pair out of response, leaving a `None` in its place.
     pub fn take_prev_kv(&mut self) -> Option<KeyValue> {
-        match self.proto.prev_kv.take() {
-            Some(kv) => Some(From::from(kv)),
-            _ => None,
-        }
+        self.proto.prev_kv.take().map(From::from)
     }
 }

--- a/src/kv/put.rs
+++ b/src/kv/put.rs
@@ -3,8 +3,8 @@ use crate::KeyValue;
 use crate::ResponseHeader;
 
 pbwrap_request!(
-/// Request for putting key-value.
-PutRequest
+    /// Request for putting key-value.
+    PutRequest
 );
 
 impl PutRequest {

--- a/src/kv/range.rs
+++ b/src/kv/range.rs
@@ -3,8 +3,8 @@ use crate::proto::etcdserverpb;
 use crate::ResponseHeader;
 
 pbwrap_request!(
-/// Request for fetching key-value pairs.
-RangeRequest
+    /// Request for fetching key-value pairs.
+    RangeRequest
 );
 
 impl RangeRequest {

--- a/src/kv/range.rs
+++ b/src/kv/range.rs
@@ -2,10 +2,10 @@ use super::{KeyRange, KeyValue};
 use crate::proto::etcdserverpb;
 use crate::ResponseHeader;
 
+pbwrap_request!(
 /// Request for fetching key-value pairs.
-pub struct RangeRequest {
-    proto: etcdserverpb::RangeRequest,
-}
+RangeRequest
+);
 
 impl RangeRequest {
     /// Creates a new RangeRequest for the specified key range.
@@ -36,17 +36,7 @@ impl RangeRequest {
     }
 }
 
-impl Into<etcdserverpb::RangeRequest> for RangeRequest {
-    fn into(self) -> etcdserverpb::RangeRequest {
-        self.proto
-    }
-}
-
-/// Response for RangeRequest.
-#[derive(Debug)]
-pub struct RangeResponse {
-    proto: etcdserverpb::RangeResponse,
-}
+pbwrap_response!(RangeResponse);
 
 impl RangeResponse {
     /// Takes the header out of response, leaving a `None` in its place.
@@ -72,11 +62,5 @@ impl RangeResponse {
     /// Returns the number of keys within the range when requested.
     pub fn count(&self) -> usize {
         self.proto.count as usize
-    }
-}
-
-impl From<etcdserverpb::RangeResponse> for RangeResponse {
-    fn from(resp: etcdserverpb::RangeResponse) -> Self {
-        Self { proto: resp }
     }
 }

--- a/src/kv/range.rs
+++ b/src/kv/range.rs
@@ -41,17 +41,15 @@ pbwrap_response!(RangeResponse);
 impl RangeResponse {
     /// Takes the header out of response, leaving a `None` in its place.
     pub fn take_header(&mut self) -> Option<ResponseHeader> {
-        match self.proto.header.take() {
-            Some(header) => Some(From::from(header)),
-            _ => None,
-        }
+        self.proto.header.take().map(From::from)
     }
 
     /// Takes the key-value pairs out of response, leaving an empty vector in its place.
     pub fn take_kvs(&mut self) -> Vec<KeyValue> {
-        let kvs = std::mem::replace(&mut self.proto.kvs, vec![]);
-
-        kvs.into_iter().map(From::from).collect()
+        std::mem::take(&mut self.proto.kvs)
+            .into_iter()
+            .map(From::from)
+            .collect()
     }
 
     /// Returns `true` if there are more keys to return in the requested range, and `false` otherwise.

--- a/src/kv/txn.rs
+++ b/src/kv/txn.rs
@@ -6,10 +6,10 @@ use crate::ResponseHeader;
 use etcdserverpb::compare::{CompareResult, CompareTarget, TargetUnion};
 use etcdserverpb::Compare;
 
+pbwrap_request!(
 /// Request for performing transaction operations.
-pub struct TxnRequest {
-    proto: etcdserverpb::TxnRequest,
-}
+TxnRequest
+);
 
 impl TxnRequest {
     /// Creates a new TxnRequest.
@@ -108,12 +108,6 @@ impl Default for TxnRequest {
     }
 }
 
-impl Into<etcdserverpb::TxnRequest> for TxnRequest {
-    fn into(self) -> etcdserverpb::TxnRequest {
-        self.proto
-    }
-}
-
 /// Transaction Operation.
 pub enum TxnOp {
     Range(RangeRequest),
@@ -122,15 +116,15 @@ pub enum TxnOp {
     Txn(TxnRequest),
 }
 
-impl Into<etcdserverpb::RequestOp> for TxnOp {
-    fn into(self) -> etcdserverpb::RequestOp {
+impl From<TxnOp> for etcdserverpb::RequestOp {
+    fn from(x: TxnOp) -> etcdserverpb::RequestOp {
         use etcdserverpb::request_op::Request;
 
-        let req = match self {
-            Self::Range(req) => Request::RequestRange(req.into()),
-            Self::Put(req) => Request::RequestPut(req.into()),
-            Self::Delete(req) => Request::RequestDeleteRange(req.into()),
-            Self::Txn(req) => Request::RequestTxn(req.into()),
+        let req = match x {
+            TxnOp::Range(req) => Request::RequestRange(req.into()),
+            TxnOp::Put(req) => Request::RequestPut(req.into()),
+            TxnOp::Delete(req) => Request::RequestDeleteRange(req.into()),
+            TxnOp::Txn(req) => Request::RequestTxn(req.into()),
         };
 
         etcdserverpb::RequestOp { request: Some(req) }
@@ -169,9 +163,9 @@ pub enum TxnCmp {
     Less,
 }
 
-impl Into<CompareResult> for TxnCmp {
-    fn into(self) -> CompareResult {
-        match self {
+impl From<TxnCmp> for CompareResult {
+    fn from(x: TxnCmp) -> CompareResult {
+        match x {
             TxnCmp::Equal => CompareResult::Equal,
             TxnCmp::NotEqual => CompareResult::NotEqual,
             TxnCmp::Greater => CompareResult::Greater,
@@ -200,11 +194,7 @@ impl From<etcdserverpb::ResponseOp> for TxnOpResponse {
     }
 }
 
-/// Response for transaction.
-#[derive(Debug)]
-pub struct TxnResponse {
-    proto: etcdserverpb::TxnResponse,
-}
+pbwrap_response!(TxnResponse);
 
 impl TxnResponse {
     /// Takes the header out of response, leaving a `None` in its place.
@@ -225,11 +215,5 @@ impl TxnResponse {
         let responses = std::mem::take(&mut self.proto.responses);
 
         responses.into_iter().map(From::from).collect()
-    }
-}
-
-impl From<etcdserverpb::TxnResponse> for TxnResponse {
-    fn from(resp: etcdserverpb::TxnResponse) -> Self {
-        Self { proto: resp }
     }
 }

--- a/src/kv/txn.rs
+++ b/src/kv/txn.rs
@@ -199,10 +199,7 @@ pbwrap_response!(TxnResponse);
 impl TxnResponse {
     /// Takes the header out of response, leaving a `None` in its place.
     pub fn take_header(&mut self) -> Option<ResponseHeader> {
-        match self.proto.header.take() {
-            Some(header) => Some(From::from(header)),
-            _ => None,
-        }
+        self.proto.header.take().map(From::from)
     }
 
     /// Returns `true` if the compare evaluated to true, and `false` otherwise.
@@ -212,8 +209,9 @@ impl TxnResponse {
 
     /// Takes the responses corresponding to the results from applying the Success block if succeeded is true or the Failure if succeeded is false.
     pub fn take_responses(&mut self) -> Vec<TxnOpResponse> {
-        let responses = std::mem::take(&mut self.proto.responses);
-
-        responses.into_iter().map(From::from).collect()
+        std::mem::take(&mut self.proto.responses)
+            .into_iter()
+            .map(From::from)
+            .collect()
     }
 }

--- a/src/kv/txn.rs
+++ b/src/kv/txn.rs
@@ -7,8 +7,8 @@ use etcdserverpb::compare::{CompareResult, CompareTarget, TargetUnion};
 use etcdserverpb::Compare;
 
 pbwrap_request!(
-/// Request for performing transaction operations.
-TxnRequest
+    /// Request for performing transaction operations.
+    TxnRequest
 );
 
 impl TxnRequest {

--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -232,7 +232,7 @@ mod tests {
 
         struct Test {
             shutdown: Arc<AtomicUsize>,
-        };
+        }
 
         #[async_trait]
         impl Shutdown for Test {

--- a/src/lease/grant.rs
+++ b/src/lease/grant.rs
@@ -4,8 +4,8 @@ use crate::proto::etcdserverpb;
 use crate::ResponseHeader;
 
 pbwrap_request!(
-/// Request for granting lease.
-LeaseGrantRequest
+    /// Request for granting lease.
+    LeaseGrantRequest
 );
 
 impl LeaseGrantRequest {

--- a/src/lease/grant.rs
+++ b/src/lease/grant.rs
@@ -3,10 +3,10 @@ use std::time::Duration;
 use crate::proto::etcdserverpb;
 use crate::ResponseHeader;
 
+pbwrap_request!(
 /// Request for granting lease.
-pub struct LeaseGrantRequest {
-    proto: etcdserverpb::LeaseGrantRequest,
-}
+LeaseGrantRequest
+);
 
 impl LeaseGrantRequest {
     /// Creates a new LeaseGrantRequest with the specified TTL.
@@ -25,16 +25,7 @@ impl LeaseGrantRequest {
     }
 }
 
-impl Into<etcdserverpb::LeaseGrantRequest> for LeaseGrantRequest {
-    fn into(self) -> etcdserverpb::LeaseGrantRequest {
-        self.proto
-    }
-}
-
-#[derive(Debug)]
-pub struct LeaseGrantResponse {
-    proto: etcdserverpb::LeaseGrantResponse,
-}
+pbwrap_response!(LeaseGrantResponse);
 
 impl LeaseGrantResponse {
     /// Takes the header out of response, leaving a `None` in its place.
@@ -53,11 +44,5 @@ impl LeaseGrantResponse {
     /// Gets the server chosen lease time-to-live in seconds.
     pub fn ttl(&self) -> u64 {
         self.proto.ttl as u64
-    }
-}
-
-impl From<etcdserverpb::LeaseGrantResponse> for LeaseGrantResponse {
-    fn from(resp: etcdserverpb::LeaseGrantResponse) -> Self {
-        Self { proto: resp }
     }
 }

--- a/src/lease/grant.rs
+++ b/src/lease/grant.rs
@@ -11,17 +11,17 @@ pbwrap_request!(
 impl LeaseGrantRequest {
     /// Creates a new LeaseGrantRequest with the specified TTL.
     pub fn new(ttl: Duration) -> Self {
-        let proto = etcdserverpb::LeaseGrantRequest {
-            ttl: ttl.as_secs() as i64,
-            id: 0,
-        };
-
-        Self { proto }
+        Self {
+            proto: etcdserverpb::LeaseGrantRequest {
+                ttl: ttl.as_secs() as i64,
+                id: 0,
+            },
+        }
     }
 
     /// Set custom lease ID.
     pub fn set_id(&mut self, id: u64) {
-        self.proto.id = id as i64
+        self.proto.id = id as i64;
     }
 }
 
@@ -30,10 +30,7 @@ pbwrap_response!(LeaseGrantResponse);
 impl LeaseGrantResponse {
     /// Takes the header out of response, leaving a `None` in its place.
     pub fn take_header(&mut self) -> Option<ResponseHeader> {
-        match self.proto.header.take() {
-            Some(header) => Some(From::from(header)),
-            _ => None,
-        }
+        self.proto.header.take().map(From::from)
     }
 
     /// Gets the lease ID for the granted lease.

--- a/src/lease/keep_alive.rs
+++ b/src/lease/keep_alive.rs
@@ -2,9 +2,9 @@ use crate::proto::etcdserverpb;
 use crate::ResponseHeader;
 
 pbwrap_request!(
-/// Request for refreshing lease.
-#[derive(Debug)]
-LeaseKeepAliveRequest
+    /// Request for refreshing lease.
+    #[derive(Debug)]
+    LeaseKeepAliveRequest
 );
 
 impl LeaseKeepAliveRequest {

--- a/src/lease/keep_alive.rs
+++ b/src/lease/keep_alive.rs
@@ -1,11 +1,11 @@
 use crate::proto::etcdserverpb;
 use crate::ResponseHeader;
 
+pbwrap_request!(
 /// Request for refreshing lease.
 #[derive(Debug)]
-pub struct LeaseKeepAliveRequest {
-    proto: etcdserverpb::LeaseKeepAliveRequest,
-}
+LeaseKeepAliveRequest
+);
 
 impl LeaseKeepAliveRequest {
     /// Creates a new LeaseKeepAliveRequest which will refresh the specified lease.
@@ -16,16 +16,7 @@ impl LeaseKeepAliveRequest {
     }
 }
 
-impl Into<etcdserverpb::LeaseKeepAliveRequest> for LeaseKeepAliveRequest {
-    fn into(self) -> etcdserverpb::LeaseKeepAliveRequest {
-        self.proto
-    }
-}
-
-#[derive(Debug)]
-pub struct LeaseKeepAliveResponse {
-    proto: etcdserverpb::LeaseKeepAliveResponse,
-}
+pbwrap_response!(LeaseKeepAliveResponse);
 
 impl LeaseKeepAliveResponse {
     /// Takes the header out of response, leaving a `None` in its place.
@@ -44,11 +35,5 @@ impl LeaseKeepAliveResponse {
     /// Get the new TTL for the lease.
     pub fn ttl(&self) -> u64 {
         self.proto.ttl as u64
-    }
-}
-
-impl From<etcdserverpb::LeaseKeepAliveResponse> for LeaseKeepAliveResponse {
-    fn from(resp: etcdserverpb::LeaseKeepAliveResponse) -> Self {
-        Self { proto: resp }
     }
 }

--- a/src/lease/keep_alive.rs
+++ b/src/lease/keep_alive.rs
@@ -10,9 +10,9 @@ pbwrap_request!(
 impl LeaseKeepAliveRequest {
     /// Creates a new LeaseKeepAliveRequest which will refresh the specified lease.
     pub fn new(id: u64) -> Self {
-        let proto = etcdserverpb::LeaseKeepAliveRequest { id: id as i64 };
-
-        Self { proto }
+        Self {
+            proto: etcdserverpb::LeaseKeepAliveRequest { id: id as i64 },
+        }
     }
 }
 
@@ -21,10 +21,7 @@ pbwrap_response!(LeaseKeepAliveResponse);
 impl LeaseKeepAliveResponse {
     /// Takes the header out of response, leaving a `None` in its place.
     pub fn take_header(&mut self) -> Option<ResponseHeader> {
-        match self.proto.header.take() {
-            Some(header) => Some(From::from(header)),
-            _ => None,
-        }
+        self.proto.header.take().map(From::from)
     }
 
     /// Gets the lease ID for the refreshed lease.

--- a/src/lease/mod.rs
+++ b/src/lease/mod.rs
@@ -187,13 +187,13 @@ impl Lease {
     /// Fetch keep alive response stream.
     pub async fn keep_alive_responses(
         &mut self,
-    ) -> impl Stream<Item = Result<LeaseKeepAliveResponse>> {
+    ) -> Result<impl Stream<Item = Result<LeaseKeepAliveResponse>>> {
         self.keep_alive_tunnel
             .write()
             .await
             .resp_receiver
             .take()
-            .unwrap()
+            .ok_or(Error::ChannelClosed)
     }
 
     /// Performs a lease refreshing operation.

--- a/src/lease/revoke.rs
+++ b/src/lease/revoke.rs
@@ -9,9 +9,9 @@ pbwrap_request!(
 impl LeaseRevokeRequest {
     /// Creates a new LeaseRevokeRequest which will revoke the specified lease.
     pub fn new(id: u64) -> Self {
-        let proto = etcdserverpb::LeaseRevokeRequest { id: id as i64 };
-
-        Self { proto }
+        Self {
+            proto: etcdserverpb::LeaseRevokeRequest { id: id as i64 },
+        }
     }
 }
 
@@ -20,9 +20,6 @@ pbwrap_response!(LeaseRevokeResponse);
 impl LeaseRevokeResponse {
     /// Takes the header out of response, leaving a `None` in its place.
     pub fn take_header(&mut self) -> Option<ResponseHeader> {
-        match self.proto.header.take() {
-            Some(header) => Some(From::from(header)),
-            _ => None,
-        }
+        self.proto.header.take().map(From::from)
     }
 }

--- a/src/lease/revoke.rs
+++ b/src/lease/revoke.rs
@@ -1,10 +1,10 @@
 use crate::proto::etcdserverpb;
 use crate::ResponseHeader;
 
+pbwrap_request!(
 /// Request for revoking lease.
-pub struct LeaseRevokeRequest {
-    proto: etcdserverpb::LeaseRevokeRequest,
-}
+LeaseRevokeRequest
+);
 
 impl LeaseRevokeRequest {
     /// Creates a new LeaseRevokeRequest which will revoke the specified lease.
@@ -15,17 +15,7 @@ impl LeaseRevokeRequest {
     }
 }
 
-impl Into<etcdserverpb::LeaseRevokeRequest> for LeaseRevokeRequest {
-    fn into(self) -> etcdserverpb::LeaseRevokeRequest {
-        self.proto
-    }
-}
-
-/// Response for revoking lease.
-#[derive(Debug)]
-pub struct LeaseRevokeResponse {
-    proto: etcdserverpb::LeaseRevokeResponse,
-}
+pbwrap_response!(LeaseRevokeResponse);
 
 impl LeaseRevokeResponse {
     /// Takes the header out of response, leaving a `None` in its place.
@@ -34,11 +24,5 @@ impl LeaseRevokeResponse {
             Some(header) => Some(From::from(header)),
             _ => None,
         }
-    }
-}
-
-impl From<etcdserverpb::LeaseRevokeResponse> for LeaseRevokeResponse {
-    fn from(resp: etcdserverpb::LeaseRevokeResponse) -> Self {
-        Self { proto: resp }
     }
 }

--- a/src/lease/revoke.rs
+++ b/src/lease/revoke.rs
@@ -2,8 +2,8 @@ use crate::proto::etcdserverpb;
 use crate::ResponseHeader;
 
 pbwrap_request!(
-/// Request for revoking lease.
-LeaseRevokeRequest
+    /// Request for revoking lease.
+    LeaseRevokeRequest
 );
 
 impl LeaseRevokeRequest {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,41 @@ pub use lease::{
 pub use response_header::ResponseHeader;
 pub use watch::{Event, EventType, Watch, WatchRequest, WatchResponse};
 
+macro_rules! pbwrap_request {
+    ($(#[$attr:meta])* $intern:ident => $name:ident) => {
+        $(#[$attr])*
+        pub struct $name {
+            proto: crate::proto::etcdserverpb::$intern,
+        }
+        impl From<$name> for crate::proto::etcdserverpb::$intern {
+            fn from(x: $name) -> Self {
+                x.proto
+            }
+        }
+    };
+    ($(#[$attr:meta])* $name:ident) => {
+        pbwrap_request!($(#[$attr])* $name => $name);
+    }
+}
+
+macro_rules! pbwrap_response {
+    ($(#[$attr:meta])* $intern:ident => $name:ident) => {
+        $(#[$attr])*
+        #[derive(Debug)]
+        pub struct $name {
+            proto: crate::proto::etcdserverpb::$intern,
+        }
+        impl From<crate::proto::etcdserverpb::$intern> for $name {
+            fn from(resp: crate::proto::etcdserverpb::$intern) -> Self {
+                Self { proto: resp }
+            }
+        }
+    };
+    ($(#[$attr:meta])* $name:ident) => {
+        pbwrap_response!($(#[$attr])* $name => $name);
+    }
+}
+
 mod auth;
 mod client;
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub use client::{Client, ClientConfig};
 pub use error::Error;
 pub use kv::{
     DeleteRequest, DeleteResponse, KeyRange, KeyValue, Kv, PutRequest, PutResponse, RangeRequest,
-    RangeResponse, TxnCmp, TxnOpResponse, TxnRequest, TxnResponse,
+    RangeResponse, TxnCmp, TxnOp, TxnOpResponse, TxnRequest, TxnResponse,
 };
 pub use lease::{
     Lease, LeaseGrantRequest, LeaseGrantResponse, LeaseKeepAliveRequest, LeaseKeepAliveResponse,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub use lease::{
     LeaseRevokeRequest, LeaseRevokeResponse,
 };
 pub use response_header::ResponseHeader;
-pub use watch::{Event, EventType, Watch, WatchRequest, WatchResponse};
+pub use watch::{Event, EventType, Watch, WatchCancelRequest, WatchCreateRequest, WatchResponse};
 
 macro_rules! pbwrap_request {
     ($(#[$attr:meta])* $intern:ident => $name:ident) => {

--- a/src/response_header.rs
+++ b/src/response_header.rs
@@ -1,9 +1,7 @@
-use crate::proto::etcdserverpb;
-
-/// Response header.
-pub struct ResponseHeader {
-    proto: etcdserverpb::ResponseHeader,
-}
+pbwrap_response!(
+/// Response header
+ResponseHeader
+);
 
 impl ResponseHeader {
     /// Get the ID of the cluster which sent the response.
@@ -24,11 +22,5 @@ impl ResponseHeader {
     /// Get the raft term when the request was applied.
     pub fn raft_term(&self) -> u64 {
         self.proto.raft_term
-    }
-}
-
-impl From<etcdserverpb::ResponseHeader> for ResponseHeader {
-    fn from(header: etcdserverpb::ResponseHeader) -> Self {
-        Self { proto: header }
     }
 }

--- a/src/response_header.rs
+++ b/src/response_header.rs
@@ -1,7 +1,4 @@
-pbwrap_response!(
-    /// Response header
-    ResponseHeader
-);
+pbwrap_response!(ResponseHeader);
 
 impl ResponseHeader {
     /// Get the ID of the cluster which sent the response.

--- a/src/response_header.rs
+++ b/src/response_header.rs
@@ -1,6 +1,6 @@
 pbwrap_response!(
-/// Response header
-ResponseHeader
+    /// Response header
+    ResponseHeader
 );
 
 impl ResponseHeader {

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -78,12 +78,7 @@ impl WatchTunnel {
         let (req_sender, mut req_receiver) = unbounded_channel::<etcdserverpb::WatchRequest>();
         let (resp_sender, resp_receiver) = unbounded_channel::<Result<WatchResponse>>();
 
-        let request = tonic::Request::new(async_stream::stream! {
-            while let Some(req) = req_receiver.recv().await {
-                yield req;
-            }
-        });
-
+        let request = tonic::Request::new(req_receiver);
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
         // monitor inbound watch response and transfer to the receiver

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -18,7 +18,7 @@
 //!     }).await?;
 //!
 //!     // print out all received watch responses
-//!     let mut inbound = client.watch(KeyRange::key("foo")).await;
+//!     let mut inbound = client.watch(KeyRange::key("foo")).await.unwrap();
 //!     tokio::spawn(async move {
 //!         while let Some(resp) = inbound.next().await {
 //!             println!("watch response: {:?}", resp);

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -101,13 +101,13 @@ impl WatchTunnel {
                 };
                 match resp {
                     Ok(Some(resp)) => {
-                        resp_sender.send(Ok(From::from(resp))).unwrap();
+                        resp_sender.send(Ok(resp.into())).unwrap();
                     }
                     Ok(None) => {
                         return;
                     }
                     Err(e) => {
-                        resp_sender.send(Err(From::from(e))).unwrap();
+                        resp_sender.send(Err(e.into())).unwrap();
                     }
                 };
             }

--- a/src/watch/watch.rs
+++ b/src/watch/watch.rs
@@ -26,11 +26,11 @@ impl From<KeyRange> for WatchCreateRequest {
 
 impl WatchCreateRequest {
     /// Creates a new WatchRequest which will subscribe events of the specified key.
-    pub fn create(mut key_range: KeyRange) -> Self {
+    pub fn create(key_range: KeyRange) -> Self {
         Self {
             proto: etcdserverpb::WatchCreateRequest {
-                key: key_range.take_key(),
-                range_end: key_range.take_range_end(),
+                key: key_range.key,
+                range_end: key_range.range_end,
                 start_revision: 0,
                 progress_notify: false,
                 filters: vec![], // TODO support filters

--- a/src/watch/watch.rs
+++ b/src/watch/watch.rs
@@ -4,11 +4,11 @@ use crate::Event;
 use crate::KeyRange;
 use crate::ResponseHeader;
 
+pbwrap_request!(
 /// Request for creating or canceling watch.
 #[derive(Debug)]
-pub struct WatchRequest {
-    proto: etcdserverpb::WatchRequest,
-}
+WatchRequest
+);
 
 impl WatchRequest {
     /// Creates a new WatchRequest which will subscribe events of the specified key.
@@ -70,16 +70,7 @@ impl WatchRequest {
     }
 }
 
-impl Into<etcdserverpb::WatchRequest> for WatchRequest {
-    fn into(self) -> etcdserverpb::WatchRequest {
-        self.proto
-    }
-}
-
-#[derive(Debug)]
-pub struct WatchResponse {
-    proto: etcdserverpb::WatchResponse,
-}
+pbwrap_response!(WatchResponse);
 
 impl WatchResponse {
     /// Takes the header out of response, leaving a `None` in its place.
@@ -100,11 +91,5 @@ impl WatchResponse {
         let events = std::mem::take(&mut self.proto.events);
 
         events.into_iter().map(From::from).collect()
-    }
-}
-
-impl From<etcdserverpb::WatchResponse> for WatchResponse {
-    fn from(resp: etcdserverpb::WatchResponse) -> Self {
-        Self { proto: resp }
     }
 }

--- a/src/watch/watch.rs
+++ b/src/watch/watch.rs
@@ -5,9 +5,9 @@ use crate::KeyRange;
 use crate::ResponseHeader;
 
 pbwrap_request!(
-/// Request for creating or canceling watch.
-#[derive(Debug)]
-WatchRequest
+    /// Request for creating or canceling watch.
+    #[derive(Debug)]
+    WatchRequest
 );
 
 impl WatchRequest {


### PR DESCRIPTION
(this adds an export of `TxnOp`, at least to make the documentation less confusing)

Fixes #43.

Additionally, this removes the `take` methods on `KeyRange` and instead makes the fields public. This improves usability, but breaks API compatibility.