### PR TITLE
Bump tokio to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ documentation = "https://docs.rs/etcd-rs"
 license = "MIT"
 
 [dependencies]
-tonic = { version = "0.3", features = ["tls"] }
-bytes = "0.5"
-prost = "0.6"
-tokio = { version = "0.2", features = ["stream"] }
+tonic = { version = "0.4", features = ["tls"] }
+bytes = "1.0"
+prost = "0.7"
+tokio = "1.0"
+tokio-stream = "^0.1"
 async-stream = "0.2"
 async-trait = "0.1"
 futures = "0.3"
@@ -22,7 +23,7 @@ thiserror = "1.0"
 http = "0.2"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "1.0", features = ["full"] }
 
 [build-dependencies]
-tonic-build = "0.3"
+tonic-build = "0.4"

--- a/examples/lease.rs
+++ b/examples/lease.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
-use futures::future::FutureExt;
-use tokio::stream::StreamExt;
+use futures::{future::FutureExt, StreamExt};
 
 use etcd_rs::*;
 

--- a/examples/watch.rs
+++ b/examples/watch.rs
@@ -1,4 +1,4 @@
-use tokio::stream::StreamExt;
+use futures::StreamExt;
 
 use etcd_rs::*;
 use tokio::time::Duration;
@@ -25,7 +25,7 @@ async fn watch(client: &Client) -> Result<()> {
         .delete(DeleteRequest::new(KeyRange::key(key)))
         .await?;
 
-    tokio::time::delay_for(Duration::from_secs(5)).await;
+    tokio::time::sleep(Duration::from_secs(5)).await;
 
     Ok(())
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use tokio::stream::Stream;
+use futures::Stream;
 use tonic::transport::ClientTlsConfig;
 use tonic::{metadata::MetadataValue, transport::Channel, Interceptor, Request};
 

--- a/src/lease/mod.rs
+++ b/src/lease/mod.rs
@@ -65,11 +65,12 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::future::FutureExt;
-use tokio::stream::Stream;
+use futures::Stream;
 use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     oneshot,
 };
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::transport::Channel;
 
 pub use grant::{LeaseGrantRequest, LeaseGrantResponse};
@@ -199,7 +200,7 @@ impl Lease {
     pub async fn keep_alive_responses(
         &mut self,
     ) -> impl Stream<Item = Result<LeaseKeepAliveResponse>> {
-        self.keep_alive_tunnel.write().await.take_resp_receiver()
+        UnboundedReceiverStream::new(self.keep_alive_tunnel.write().await.take_resp_receiver())
     }
 
     /// Performs a lease refreshing operation.

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -5,7 +5,7 @@
 //! Watch key `foo` changes
 //!
 //! ```no_run
-//! use tokio::stream::StreamExt;
+//! use futures::StreamExt;
 //!
 //! use etcd_rs::*;
 //!
@@ -46,11 +46,12 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::future::FutureExt;
-use tokio::stream::Stream;
+use futures::Stream;
 use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     oneshot,
 };
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::transport::Channel;
 
 pub use watch::{WatchRequest, WatchResponse};
@@ -163,7 +164,7 @@ impl Watch {
             .req_sender
             .send(WatchRequest::create(key_range))
             .expect("emit watch request");
-        tunnel.take_resp_receiver()
+        UnboundedReceiverStream::new(tunnel.take_resp_receiver())
     }
 
     /// Shut down the running watch task, if any.


### PR DESCRIPTION
This bumps the tokio version to 1.0, along with some transitive dependencies (bytes, prost, tonic). The following changes are necessary to make this upgrade work:

* Tokio 1.0 no longer exports `Stream` so `futures::Stream` is used instead.
* `Receiver` / `UnboundedReceiver` no longer implement `Stream`, but the `tokio-stream` crate adds a few wrapper types for them that do implement that trait. In the 2 functions that had an `impl Stream` return type and the underlying type was `UnboundedReceiver`, this now wraps them in an [UnboundedReceiverStream](https://docs.rs/tokio-stream/0.1.2/tokio_stream/wrappers/struct.UnboundedReceiverStream.html) before returning them. 
* `tokio::time::delay_for` is now `tokio::time::sleep`.

Note that #40 was targeting tokio 0.3 but given 1.0 is out, there's not much point in doing that intermediate upgrade at this point.