### PR TITLE
Upgrade tonic to 0.5, prost to 0.8, and bump version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcd-rs"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["ccc <currantxx@gmail.com>"]
 edition = "2018"
 keywords = ["etcd", "future", "async"]
@@ -11,9 +11,9 @@ documentation = "https://docs.rs/etcd-rs"
 license = "MIT"
 
 [dependencies]
-tonic = { version = "0.4", features = ["tls"] }
+tonic = { version = "0.5", features = ["tls"] }
 bytes = "1.0"
-prost = "0.7"
+prost = "0.8"
 tokio = "1.0"
 tokio-stream = "^0.1"
 async-stream = "0.3"
@@ -26,4 +26,4 @@ http = "0.2"
 tokio = { version = "1.0", features = ["full"] }
 
 [build-dependencies]
-tonic-build = "0.4"
+tonic-build = "0.5"


### PR DESCRIPTION
This PR:
* Upgrades tonic to 0.5
* Upgrades prost to 0.8 (fixes https://rustsec.org/advisories/RUSTSEC-2021-0073.html )
* Bumps version to 0.6.0

Part of the new version of tonic is that they messed up the types for interceptors, so they were moved up an abstraction layer into the Auth/Lease/etc components.